### PR TITLE
Fix: Remove @types/node as a FE Dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@types/node": "^25.5.2",
     "axios": "^1.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"


### PR DESCRIPTION
A fix to a bug with the FE build. Removal of the dependency @types/node fixes the build issue.